### PR TITLE
add bower package

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-leaflet-marker-cluster/index.js
+++ b/blueprints/ember-leaflet-marker-cluster/index.js
@@ -1,0 +1,21 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'pull leaflet.markercluster assets using bower',
+
+  // locals: function(options) {
+  //   // Return custom template variables here.
+  //   return {
+  //     foo: options.entity.options.foo
+  //   };
+  // }
+
+  normalizeEntityName: function() {
+   // this prevents an error when the entityName is
+   // not specified (since that doesn't actually matter
+   // to us
+  },
+
+  afterInstall: function(options) {
+   return this.addBowerPackageToProject('leaflet.markercluster', '~0.4.0-hotfix.1');
+  }
+};


### PR DESCRIPTION
This pulls the bower package in the consuming app when `ember install ember-leaflet-marker-cluster` is run.