### PR TITLE
FastBoot compatibility & contextual components

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,21 @@ This plugin is based on a JS library [Leaflet.markercluster](https://github.com/
 Please be advised that for some particular reason Leaflet Marker Cluster breaks if the component loads with some markers inside the marker cluster in place without `maxZoom` property provided on `{{leaflet-map}}` like so: `{{leaflet-map maxZoom=25}}`.
 
 ```handlebars
-{{#leaflet-map lat=lat lng=lng zoom=zoom}}
+{{#leaflet-map lat=lat lng=lng zoom=zoom as |layers|}}
 
-  {{tile-layer url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
-  {{#marker-cluster-layer}}
-	  {{#each markers as |marker|}}
-	    {{#marker-layer location=marker.location}}
-	      {{#popup-layer}}
-			    <h3>{{marker.title}}</h3>
-			    {{marker.description}}
-			  {{/popup-layer}}  
-			{{/marker-layer}}
-	  {{/each}}
+  {{layers.tile url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
+
+  {{#marker-cluster-layer as |cluster|}}
+    {{#each markers as |someMarker|}}
+      {{#cluster.marker location=someMarker.location as |marker|}}
+        {{#marker.popup}}
+          <h3>{{someMarker.title}}</h3>
+          {{someMarker.description}}
+        {{/marker.popup}}
+      {{/cluster.marker}}
+    {{/each}}
   {{/marker-cluster-layer}}
+
 {{/leaflet-map}}
 ```
 

--- a/addon/components/marker-cluster-layer.js
+++ b/addon/components/marker-cluster-layer.js
@@ -1,7 +1,10 @@
 import BaseLayer from 'ember-leaflet/components/base-layer';
 import { ParentMixin } from 'ember-composability-tools';
+import layout from '../templates/marker-cluster-layer';
 
 export default BaseLayer.extend(ParentMixin, {
+	layout,
+
 	leafletOptions: [
   	'showCoverageOnHover', 'zoomToBoundsOnClick', 'spiderfyOnMaxZoom', 'removeOutsideVisibleBounds',
   	'animate', 'animateAddingMarkers', 'disableClusteringAtZoom', 'maxClusterRadius', 'polygonOptions',

--- a/addon/templates/marker-cluster-layer.hbs
+++ b/addon/templates/marker-cluster-layer.hbs
@@ -1,0 +1,3 @@
+{{yield (hash
+    marker=(component "marker-layer" containerLayer=this)
+  )}}

--- a/index.js
+++ b/index.js
@@ -5,8 +5,13 @@ module.exports = {
   name: 'ember-leaflet-marker-cluster',
 
   included: function(app){
-  	app.import(app.bowerDirectory + '/leaflet.markercluster/dist/leaflet.markercluster.js');
+
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+  	  app.import(app.bowerDirectory + '/leaflet.markercluster/dist/leaflet.markercluster.js');
+    }
+
   	app.import(app.bowerDirectory + '/leaflet.markercluster/dist/MarkerCluster.css');
   	app.import(app.bowerDirectory + '/leaflet.markercluster/dist/MarkerCluster.Default.css');
+    
   }
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "cluster"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-htmlbars": "^1.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
This pull request forks @cesarizu's good commits on contextual component compatibility.

Implementing [Fastboot](https://github.com/ember-fastboot/ember-cli-fastboot) in my app caused an error from referencing `leaflet.markercluster.js`.

Adding a conditional around the bower package import resolved the issue:

```javascript
# index.js
if (!process.env.EMBER_CLI_FASTBOOT) {
  app.import(app.bowerDirectory + '/leaflet.markercluster/dist/leaflet.markercluster.js');
}
```

Here's a link to the Fastboot [addon author guides](https://ember-fastboot.com/docs/addon-author-guide).