### PR TITLE
Moves from bower to npm for sourcing leaflet.markercluster

### DIFF
--- a/blueprints/ember-leaflet-marker-cluster/index.js
+++ b/blueprints/ember-leaflet-marker-cluster/index.js
@@ -1,21 +1,9 @@
 /*jshint node:true*/
 module.exports = {
-  description: 'pull leaflet.markercluster assets using bower',
-
-  // locals: function(options) {
-  //   // Return custom template variables here.
-  //   return {
-  //     foo: options.entity.options.foo
-  //   };
-  // }
-
   normalizeEntityName: function() {
    // this prevents an error when the entityName is
    // not specified (since that doesn't actually matter
    // to us
-  },
-
-  afterInstall: function(options) {
-   return this.addBowerPackageToProject('leaflet.markercluster', '~1.0.0');
   }
+
 };

--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,6 @@
     "ember-resolver": "~0.1.20",
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
-    "qunit": "~1.20.0",
-    "leaflet": "~1.0.1",
-    "leaflet.markercluster": "~1.0.0"
+    "qunit": "~1.20.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,58 @@
 /* jshint node: true */
 'use strict';
 
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
+var path = require('path');
+
 module.exports = {
   name: 'ember-leaflet-marker-cluster',
 
-  included: function(app){
+  included(app) {
 
-    if (!process.env.EMBER_CLI_FASTBOOT) {
-  	  app.import(app.bowerDirectory + '/leaflet.markercluster/dist/leaflet.markercluster.js');
+    if (!isFastBoot()) {
+
+      const vendor = this.treePaths.vendor;
+
+      // Main modules
+      app.import(vendor + '/leaflet.markercluster/leaflet.markercluster.js');
+      app.import(vendor + '/leaflet.markercluster/MarkerCluster.css');
+      app.import(vendor + '/leaflet.markercluster/MarkerCluster.Default.css');
+
     }
 
-  	app.import(app.bowerDirectory + '/leaflet.markercluster/dist/MarkerCluster.css');
-  	app.import(app.bowerDirectory + '/leaflet.markercluster/dist/MarkerCluster.Default.css');
-    
-  }
+    return this._super.included.apply(this, arguments);
+  },
+
+  treeForVendor(vendorTree) {
+    var trees = [];
+
+    if (vendorTree) {
+      trees.push(vendorTree);
+    }
+
+    trees.push(moduleToFunnel('leaflet.markercluster', {
+      include: ['*.js', '*.css'],
+      destDir: 'leaflet.markercluster'
+    }));
+
+    return mergeTrees(trees);
+  },
+
 };
+
+function moduleToFunnel(moduleName, opts) {
+  opts = opts || { destDir: moduleName };
+  return new Funnel(resolveModulePath(moduleName), opts);
+}
+
+function resolveModulePath(moduleName) {
+  return path.dirname(require.resolve(moduleName));
+}
+
+// Checks to see whether this build is targeting FastBoot. Note that we cannot
+// check this at boot time--the environment variable is only set once the build
+// has started, which happens after this file is evaluated.
+function isFastBoot() {
+  return process.env.EMBER_CLI_FASTBOOT === 'true';
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -34,7 +36,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-leaflet": "^3.0.2",
+    "ember-leaflet": "^3.0.11",
     "ember-try": "~0.0.8"
   },
   "keywords": [
@@ -49,7 +51,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.3"
+    "ember-cli-htmlbars": "^1.0.3",
+    "leaflet": "^1.0.3",
+    "leaflet.markercluster": "^1.0.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
The following PR follows Ember Leaflet's lead in removing Bower dependencies in favour of NPM modules.

- Adds `broccoli-funnel` & `broccoli-merge-trees` to get the NPM package into vendor
- Imports `leaflet.markercluster` from vendor
- Updates `Ember Leaflet` to `3.0.11`