### PR TITLE
Fixes style dependency imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,33 +39,17 @@ module.exports = {
       })
     );
 
-    trees.push(
-      debugTree(js, 'leaflet.markercluster:js')
-    );
-
-    return debugTree(mergeTrees(trees), 'mergedVendorTrees');
-  },
-
-  treeForStyles(styleTree) {
-    let debugTree = BroccoliDebug.buildDebugCallback(this.name),
-        trees = [];
-
-    if (styleTree) {
-      trees.push(
-        debugTree(styleTree, 'styleTree')
-      );
-    }
-
     let css = moduleToFunnel('leaflet.markercluster', {
       include: ['*.css'],
       destDir: 'leaflet.markercluster'
     });
 
     trees.push(
+      debugTree(js, 'leaflet.markercluster:js'),
       debugTree(css, 'leaflet.markercluster:css')
     );
 
-    return debugTree(mergeTrees(trees), 'mergedStyleTrees');
+    return debugTree(mergeTrees(trees), 'mergedVendorTrees');
   }
 
 };


### PR DESCRIPTION
PR #20 introduced Fastboot 1.0.0 compatibility, but didn't use quite the right pattern for style imports. 

This PR fixes the incorrect usage of the `treeForStyles` hook and ensures `leaflet.markercluster:css` is included in the `treeForVendor` hook instead.